### PR TITLE
Add ability to specify an image size for media entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install tweet-to-html -S
 
 ## Usage
 
-There is only one method named `parse`. You can pass in a tweet object or an array of objects. The response will be object/array tweet object with a new property named `html` with the parsed output.
+There is only one method named `parse`. You can pass in a tweet object or an array of objects, and an optional config object. The response will be object/array tweet object with a new property named `html` with the parsed output.
 
 
 ```
@@ -25,6 +25,12 @@ var tweetToHTML = require('tweet-to-html');
 
 var result  = tweetToHTML.parse(tweetObj); //Single tweet object
 var results = tweetToHTML.parse(tweetArr); //Multiple tweets in an array
+
+var photoConfig = {
+  photoSize: 'large' // Any size supported by the `media` entity (thumb, small, medium...)
+};
+
+var result  = tweetToHTML.parse(tweetObj, photoConfig); //Single tweet object with specified image size
 
 //output
 console.log(result.html);

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ var twemoji = require('twemoji' );
 
 module.exports.parse = parseTweets;
 
+var options = {};
 
-function parseTweets(tweets) {
+function parseTweets(tweets, opts) {
+  options = opts;
   return Array.isArray(tweets) ? tweets.map(parseTweet) : parseTweet(tweets);
 }
 
@@ -78,7 +80,18 @@ function processUrls(urls, tweetObj) {
 function processMedia(media, tweetObj) {
   media.forEach((mediaObj) => {
     if(mediaObj.type === 'photo') {
-      var image = '<img src="' + mediaObj.media_url + '"/>';
+      // Use HTTPS if available
+      var src = mediaObj.media_url_https ? mediaObj.media_url_https : mediaObj.media_url;
+
+      if(options &&
+        options.photoSize &&
+        mediaObj.sizes &&
+        mediaObj.sizes[options.photoSize]) {
+        // If specified size is available, patch image src to use it
+        src = src + ':' + options.photoSize;
+      }
+
+      var image = '<img src="' + src + '"/>';
       tweetObj.html = tweetObj.html.replace(mediaObj.url, image);
     } else if(mediaObj.type === 'video') {
       var source = '';

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ var tweetWithLinksPicMention = require('./tweets/tweet-with-links-pic-mention');
 var tweetWithLinksPicMentionExpected = require('./tweets/tweet-with-links-pic-mention-expected');
 var tweetWitUsernameMixedCases = require('./tweets/tweet-with-username-mixed-cases');
 var tweetWitUsernameMixedCasesExpected = require('./tweets/tweet-with-username-mixed-cases-expected');
+var tweetWithSpecifiedImgSizeExpected = require('./tweets/tweet-with-specified-img-size-expected');
 
 var tweetBug3 = require('./tweets/tweet-bug-3');
 var tweetBug3Expected = require('./tweets/tweet-bug-3-expected');
@@ -39,6 +40,10 @@ describe("Synchronous and Single Tweet Test Suite", function() {
 
   it('Synchonous parsing of usernames with mixed cases in tweet is successful', function() {
     assert.strictEqual(parse(tweetWithLinksPicMention).html, tweetWithLinksPicMentionExpected);
+  });
+
+  it('Synchonous parsing of picture with specified image size is successful', function() {
+    assert.strictEqual(parse(tweetWithLinksPicMention, { photoSize: 'thumb' }).html, tweetWithSpecifiedImgSizeExpected);
   });
 });
 

--- a/test/tweets/tweet-with-links-pic-mention-expected.js
+++ b/test/tweets/tweet-with-links-pic-mention-expected.js
@@ -1,1 +1,1 @@
-module.exports = 'Facebook Should Reword Confusing Hack Warning About "State-Sponsored Actors" <a href="http://tcrn.ch/1Mzi1dM">tcrn.ch/1Mzi1dM</a> by <a href="http://twitter.com/JoshConstine">@JoshConstine</a> <img src="http://pbs.twimg.com/media/CRsdAZVVAAASi1S.png"/>';
+module.exports = 'Facebook Should Reword Confusing Hack Warning About "State-Sponsored Actors" <a href="http://tcrn.ch/1Mzi1dM">tcrn.ch/1Mzi1dM</a> by <a href="http://twitter.com/JoshConstine">@JoshConstine</a> <img src="https://pbs.twimg.com/media/CRsdAZVVAAASi1S.png"/>';

--- a/test/tweets/tweet-with-specified-img-size-expected.js
+++ b/test/tweets/tweet-with-specified-img-size-expected.js
@@ -1,0 +1,1 @@
+module.exports = 'Facebook Should Reword Confusing Hack Warning About "State-Sponsored Actors" <a href="http://tcrn.ch/1Mzi1dM">tcrn.ch/1Mzi1dM</a> by <a href="http://twitter.com/JoshConstine">@JoshConstine</a> <img src="https://pbs.twimg.com/media/CRsdAZVVAAASi1S.png:thumb"/>';


### PR DESCRIPTION
Add a few small improvements:
* Allow the user to pass an optional config object in
* Add an option to the new config that enforces one of the supported sizes for images (main use case is to specify "thumb" in order to request a small image and save on network usage)
* If HTTPS is available for an image, use it instead of HTTP
* Add a new fixture and test