### PR TITLE
#8 Add support for extended_mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,14 @@ function parseTweet(tweetObj) {
   var entities = tweetObj.entities;
   var processorObj;
 
-  //Copying text value to a new property html. The final output will be set to this property
   //When extended_mode is enabled, the text property will be empty and the value of the html property will be set to the full_text value
-  tweetObj.html = tweetObj.text || tweetObj.full_text ;
+  //Replace the text property because the property is used in other functions (i.e. processUrls)
+  if (tweetObj.full_text) {
+    tweetObj.text = tweetObj.full_text;
+  }
+
+  //Copying text value to a new property html. The final output will be set to this property
+  tweetObj.html = tweetObj.text
 
   //Process entities
   if(Object.getOwnPropertyNames(entities).length) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function parseTweet(tweetObj) {
   }
 
   //Copying text value to a new property html. The final output will be set to this property
-  tweetObj.html = tweetObj.text
+  tweetObj.html = tweetObj.text;
 
   //Process entities
   if(Object.getOwnPropertyNames(entities).length) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function parseTweet(tweetObj) {
   var processorObj;
 
   //Copying text value to a new property html. The final output will be set to this property
-  tweetObj.html = tweetObj.text;
+  //When extended_mode is enabled, the text property will be empty and the value of the html property will be set to the full_text value
+  tweetObj.html = tweetObj.text || tweetObj.full_text ;
 
   //Process entities
   if(Object.getOwnPropertyNames(entities).length) {


### PR DESCRIPTION
A [previous PR](https://github.com/blessenm/tweet-to-html/pull/9) was made for this issue, but was not followed up on. The comment @blessenm made was at first sight valid, but isn't foolproof since the text property of the tweet object is used in the processUrl function. 

If the extended mode is enabled, then the text property isn't set and the code errors on this [line](https://github.com/blessenm/tweet-to-html/blob/master/index.js#L68).

I remade the PR, since I needed to start from the latest version where https media is supported.